### PR TITLE
DRPLDCX-22 Delete migrate map entry on media deletion

### DIFF
--- a/modules/dcx_migration/dcx_migration.module
+++ b/modules/dcx_migration/dcx_migration.module
@@ -39,3 +39,14 @@ function template_preprocess_dcxdropzone(&$variables) {
 
   $variables['dropvalue'] = $element['dropvalue'];
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function dcx_migration_media_delete(Drupal\Core\Entity\EntityInterface $entity) {
+  // Remove the migrate map entry for this entity to allow remigration.
+  $db = Drupal\Core\Database\Database::getConnection('default');
+  $query = $db->delete('migrate_map_dcx_migration')
+    ->condition('destid1', $entity->id())
+    ->execute();
+}


### PR DESCRIPTION
This should fix the problem that you can't reimport an image from DC-X after deleting it.

Steps to reproduce:
- Import media by dnd on dcx-migration/import
- Delete import deleted media item
- reimport it by dnd
- Find the media item imported again without error message
