### PR TITLE
DRPLDCX-57 Remove pubinfo when media is deleted

### DIFF
--- a/modules/dcx_integration_debug/src/MockClient.php
+++ b/modules/dcx_integration_debug/src/MockClient.php
@@ -91,5 +91,11 @@ class MockClient implements ClientInterface {
     return [];
   }
 
+  /**
+   * {{@inheritdoc}}
+   */
+  public function removeAllUsage($dcx_id) {
+    dpm($dcx_id, __METHOD__);
+  }
 
 }

--- a/modules/dcx_track_media_usage/dcx_track_media_usage.module
+++ b/modules/dcx_track_media_usage/dcx_track_media_usage.module
@@ -4,17 +4,34 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\field\Entity\FieldConfig;
 
 /**
- * Implement hook_entity_insert()-
+ * Implement hook_ENTITY_TYPE_insert().
  */
 function dcx_track_media_usage_node_insert($entity) {
   _dcx_track_media_usage_track_media_usage($entity);
 }
 
 /**
- * Implement hook_entity_insert()-
+ * Implement hook_ENTITY_TYPE_insert().
  */
 function dcx_track_media_usage_node_update($entity) {
   _dcx_track_media_usage_track_media_usage($entity);
+}
+
+/*
+ * Implement hook_ENTITY_TYPE_delete()-
+ */
+function dcx_track_media_usage_media_delete($entity) {
+  if ('image' !== $entity->bundle()) {
+    return;
+  }
+
+  $dcx_id = $entity->field_dcx_id->value;
+  try {
+    Drupal::service('dcx_integration.client')->removeAllUsage($dcx_id);
+  }
+  catch (\Exception $e) {
+    drupal_set_message($e->getMessage(), 'error');
+  }
 }
 
 /**
@@ -25,7 +42,7 @@ function _dcx_track_media_usage_track_media_usage($entity) {
   $usage = $discovery->discover($entity);
 
   $url = $entity->toUrl()->getInternalPath();
-  
+
   $status = $entity->status->value;
   try {
     Drupal::service('dcx_integration.client')->trackUsage($usage, $url, $status);

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -53,7 +53,18 @@ interface ClientInterface {
    *
    * @param string $path canonical path (e.g. node/23)
    *
-   * return array of array of pubinfo data keyed by DC-X document ID
+   * @return array of array of pubinfo data keyed by DC-X document ID
    */
   public function pubinfoOnPath($path);
+
+
+  /**
+   * Removes all usage information about the given DC-X ID on the current site.
+   *
+   * The main reason for calling this would be deleteing the entity representin
+   * the given ID.
+   *
+   * @param string $dcx_id the DC-X document ID
+   */
+  public function removeAllUsage($dcx_id);
 }

--- a/src/JsonClient.php
+++ b/src/JsonClient.php
@@ -468,7 +468,16 @@ class JsonClient implements ClientInterface {
     return $pubinfo;
   }
 
-  public function removePubinfos($pubinfos) {
+  /**
+   * Deletes the given pubinfo entries
+   *
+   * This just deletes. It does not make any sanity checks at all.
+   *
+   * @param array $pubinfos list of pubinfo entries as returned by DC-X.
+   *
+   * @throws \Exception
+   */
+  protected function removePubinfos($pubinfos) {
     foreach ($pubinfos as $data) {
       $dcx_api_url = $data['_id_url'];
       $http_status = $this->api_client->deleteObject($dcx_api_url, [], $response_body);
@@ -478,5 +487,20 @@ class JsonClient implements ClientInterface {
         throw new \Exception($message);
       }
     }
+  }
+
+  /**
+   * {{@inheritdoc}}
+   */
+  public function removeAllUsage($dcx_id) {
+    $document = $this->getJson($dcx_id);
+    $pubinfos = $document['_referenced']['dcx:pubinfo'];
+
+    foreach ($pubinfos as $key => $pubinfo) {
+      if ("dcxapi:tm_topic/" . $this->publication_id !== $pubinfo['properties']['publication_id']['_id']) {
+        unset($pubinfos[$key]);
+      }
+    }
+    $this->removePubinfos($pubinfos);
   }
 }


### PR DESCRIPTION
STR:
- Prepare: Use a media image on
  - two different articles
  - one article with a different publication id (admin/config/dcx_integration/jsonclientsettings)
  - DON'T use it as field_heaser_media (Bug in thunder!)
- Find the usage info on the image in DC-X (-> Verwendung)
- Delete the image entity in Drupal
- Find the usage info for the configured publication gone in DC-X

BTW: Right now, images attached to articles may still be attached to the respective DC-X Document. I talked to Digicol about this. This is going to be resolved in an other way.
