### PR TITLE
DRPLDCX-63 Make article archive queue dispatching work when triggered via drush

### DIFF
--- a/modules/dcx_article_archive/src/Plugin/QueueWorker/ArticleArchiver.php
+++ b/modules/dcx_article_archive/src/Plugin/QueueWorker/ArticleArchiver.php
@@ -114,7 +114,7 @@ class ArticleArchiver extends QueueWorkerBase implements ContainerFactoryPluginI
 
     $url = $node->toUrl()->setAbsolute()->toString();
 
-    // This is NULL for new article and that's perfectly fine.
+    // This is NULL for new articles and that's perfectly fine.
     $existing_dcx_id = $node->field_dcx_id->value;
 
     try {
@@ -141,6 +141,7 @@ class ArticleArchiver extends QueueWorkerBase implements ContainerFactoryPluginI
     // If the DC-X ID has changed, we need to save the id to the entity.
     if ($existing_dcx_id !== $dcx_id) {
       $node->set('field_dcx_id', $dcx_id, FALSE);
+      // Prevent requeuing for archiving. See dcx_article_archive_node_update().
       $node->DO_NOT_QUEUE_AGAIN = TRUE;
       $node->save();
     }


### PR DESCRIPTION
of dcx_article_archiver queue worker.

STR:
- Save an article/Make sure the dcx_article_archive queue is not empty
- run drush core-cron
- find the dcx_article_archive queue processed without error
