### PR TITLE
Normalize destination URI before saving file

### DIFF
--- a/modules/dcx_migration/src/Plugin/migrate/process/FileFromURL.php
+++ b/modules/dcx_migration/src/Plugin/migrate/process/FileFromURL.php
@@ -114,8 +114,12 @@ class FileFromUrl extends ProcessPluginBase implements ContainerFactoryPluginInt
     $tmp_name = tempnam('temp://', 'dcx-');
     file_put_contents($tmp_name, $file_data);
 
-    // Copy tempfile to destination.
-    $uri = file_unmanaged_copy($tmp_name, $destination_uri . DIRECTORY_SEPARATOR . $file_name, FILE_EXISTS_RENAME);
+    // Copy tempfile to destination, make sure to use canonical file uri
+    $uri = file_unmanaged_copy(
+      $tmp_name,
+      file_stream_wrapper_uri_normalize($destination_uri . DIRECTORY_SEPARATOR . $file_name),
+      FILE_EXISTS_RENAME
+    );
 
     // Remove.
     unlink($tmp_name);


### PR DESCRIPTION
Concatenating $destination_uri and a DIRECTORY_SEPARATOR can lead to situations where the file URI has too many slashes in the scheme part, e.g. "public:///". This is then saved into the file entity, ultimately ending up in the file_managed table.

This is usually not a problem as Drupal understands this kind of URI and also normalizes this to two slashes on a number of occasions. However, versions of the focal_point module that do not use the Crop API yet will try to compare a loaded file's URI with the string saved into the file_managed table (in FocalPoint::getFromURI()) and subsequently fails to load the correct data.

This patch just puts the final destination URI through the appropriate Drupal function that cleans it up.
