### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "burdamagazinorg/dcx-integration",
+  "name": "burdamagazinorg/dcx_integration",
   "type": "drupal-module",
   "description": "Module DC-X Integration",
   "license": "proprietary",


### PR DESCRIPTION
Drupal uses underscore instead of hyphen for module names.
