### PR TITLE
DRPLDCX-12 Import articles

### DIFF
--- a/modules/dcx_article_import/css/dcx-article-import-ui.css
+++ b/modules/dcx_article_import/css/dcx-article-import-ui.css
@@ -1,0 +1,16 @@
+.dcx-dropzone {
+  width: 100%;
+  padding: 1em;
+  min-height: 3em;
+  background-color: white;
+  outline: 2px dashed #0074bd;
+  color: #004f80;
+  box-sizing: border-box;
+  margin-bottom: 1em;
+}
+
+.message {
+  text-align: center;
+  margin-top: 1em;
+  margin-bottom: 1em;
+}

--- a/modules/dcx_article_import/dcx_article_import.info.yml
+++ b/modules/dcx_article_import/dcx_article_import.info.yml
@@ -1,0 +1,8 @@
+name: DC-X Article Import
+type: module
+description: Allow importing DC-X story object to article nodes.
+core: 8.x
+package: dcx
+
+dependencies:
+  - dcx_integration

--- a/modules/dcx_article_import/dcx_article_import.info.yml
+++ b/modules/dcx_article_import/dcx_article_import.info.yml
@@ -1,6 +1,6 @@
 name: DC-X Article Import
 type: module
-description: Allow importing DC-X story object to article nodes.
+description: Allow importing DC-X story documents to article nodes.
 core: 8.x
 package: dcx
 

--- a/modules/dcx_article_import/dcx_article_import.info.yml
+++ b/modules/dcx_article_import/dcx_article_import.info.yml
@@ -6,3 +6,4 @@ package: dcx
 
 dependencies:
   - dcx_integration
+  - dcx_migration

--- a/modules/dcx_article_import/dcx_article_import.libraries.yml
+++ b/modules/dcx_article_import/dcx_article_import.libraries.yml
@@ -1,0 +1,8 @@
+dropzone:
+  version: 0
+  js:
+    js/dcx-article-import-ui.js: {}
+  css:
+    theme:
+      css/dcx-article-import-ui.css: {}
+

--- a/modules/dcx_article_import/dcx_article_import.module
+++ b/modules/dcx_article_import/dcx_article_import.module
@@ -1,0 +1,49 @@
+<?php
+
+use Drupal\Core\Url;
+
+/**
+ * Implement hook_menu_local_tasks_alter.
+ *
+ * Add local tasks to dcx_article_import.form and node.add with parameter
+ * 'article'. Adding local tasks to a route only for a specific parameter is
+ * not possible via *.task.yml, so we need this hack.
+ */
+function dcx_article_import_menu_local_tasks_alter(&$data, $route_name) {
+  if ('node.add' == $route_name) {
+    // For page.add we need to turn off caching to allow the tabs to be computed
+    // everytime we visit the route, as the tabs should only show up for our
+    // parameter
+    $data['cacheability']->setCacheMaxAge(0);
+
+    // This is ugly like hell, but apparently the way to do this atm:
+    // https://www.drupal.org/node/2274705
+    $current_path = \Drupal::service('path.current')->getPath();
+    $path_args = explode('/', $current_path);
+    // $current_path began with a slash, so this starts to count at 1
+    if ('article' == $path_args[3]) {
+      $node_add_article = TRUE;
+    }
+  }
+
+  if ($node_add_article || 'dcx_article_import.form' == $route_name) {
+    $data['tabs'][] = [
+      'node.add.article' => [
+        '#theme' => 'menu_local_task',
+        '#active' => ('node.add' == $route_name),
+        '#link' => [
+          'title' => \Drupal::translation()->translate('Add'),
+          'url' => Url::fromRoute('node.add', ['node_type' => 'article'])
+        ],
+      ],
+      'dcx_article_import.form' => [
+        '#theme' => 'menu_local_task',
+        '#active' => ('dcx_article_import.form' == $route_name),
+        '#link' => [
+          'title' => \Drupal::translation()->translate('DC-X Import'),
+          'url' => Url::fromRoute('dcx_article_import.form'),
+        ],
+      ]
+    ];
+  }
+}

--- a/modules/dcx_article_import/dcx_article_import.module
+++ b/modules/dcx_article_import/dcx_article_import.module
@@ -10,6 +10,8 @@ use Drupal\Core\Url;
  * not possible via *.task.yml, so we need this hack.
  */
 function dcx_article_import_menu_local_tasks_alter(&$data, $route_name) {
+  $node_add_article = FALSE;
+
   if ('node.add' == $route_name) {
     // For page.add we need to turn off caching to allow the tabs to be computed
     // everytime we visit the route, as the tabs should only show up for our

--- a/modules/dcx_article_import/dcx_article_import.routing.yml
+++ b/modules/dcx_article_import/dcx_article_import.routing.yml
@@ -1,0 +1,9 @@
+dcx_article_import.form:
+  path: '/node/add/article/dcx-import'
+  defaults:
+    _form: '\Drupal\dcx_article_import\Form\ArticleImportForm'
+    _title: 'Import articles from DC-X'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _permission: 'import from dcx'

--- a/modules/dcx_article_import/js/dcx-article-import-ui.js
+++ b/modules/dcx_article_import/js/dcx-article-import-ui.js
@@ -1,0 +1,49 @@
+/**
+ * @file
+ */
+
+(function ($, Drupal, drupalSettings) {
+  'use strict';
+
+  Drupal.behaviors.dcxArticleImportUi = {
+    attach: function (context, settings) {
+      var submitButton = $('#edit-submit');
+      var textfield = $('#edit-dcx-id');
+
+      var dropzone = $('<div></div>').addClass('dcx-dropzone');
+      var message = $('<div>' + Drupal.t('Drop DC-X story link here!') + '</div>').addClass('message').appendTo(dropzone);
+      dropzone.insertBefore(textfield);
+
+      dropzone.on('dragover dragenter', function (event) {
+        event.preventDefault();
+      });
+
+      dropzone.on('dragleave dragend drop', function (event) {
+        event.preventDefault();
+      });
+
+      dropzone.on('drop', function (event) {
+        event.preventDefault();
+
+        var uris = decodeURIComponent(event.originalEvent.dataTransfer.getData('text/plain')).split('\n');
+        if (uris.length != 1) {
+          dropzone.css('backgroundColor', '#FFC0CB');
+          message.html(Drupal.t('Please provide exactly one link!'));
+          return;
+        }
+        var match = uris[0].match(/(document\/doc[\w]+).*x-doctype=documenttype-story/);
+
+        if (!match) {
+          dropzone.css('backgroundColor', '#FFC0CB');
+          message.html(Drupal.t('Please provide a valid story link!'));
+        }
+
+        var id = match[1];
+
+        textfield.val(id);
+        submitButton.click();
+      });
+    }
+  };
+
+})(jQuery, Drupal, drupalSettings);

--- a/modules/dcx_article_import/src/Form/ArticleImportForm.php
+++ b/modules/dcx_article_import/src/Form/ArticleImportForm.php
@@ -9,8 +9,14 @@ namespace Drupal\dcx_article_import\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\dcx_integration\ClientInterface;
+use Drupal\dcx_migration\DcxImportServiceInterface;
+use Drupal\node\Entity\Node;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\user\PrivateTempStoreFactory;
+use Drupal\user\PrivateTempStore;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class ArticleImportForm.
@@ -20,22 +26,47 @@ use Drupal\dcx_integration\ClientInterface;
 class ArticleImportForm extends FormBase {
 
   /**
-   * Drupal\dcx_integration\ClientInterface definition.
+   * DC-X Client.
    *
    * @var Drupal\dcx_integration\ClientInterface
    */
   protected $dcx_integration_client;
 
-  public function __construct(ClientInterface $dcx_integration_client) {
+  /**
+   * DC-X Import service.
+   *
+   * @var Drupal\dcx_migration\DcxImportServiceInterface
+   */
+  protected $dcx_import_service;
+
+  /**
+   * Temporary storage.
+   *
+   * @var Drupal\user\PrivateTempStore
+   */
+  protected $store;
+
+  /**
+   * The current user account.
+   * @var Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $user_account;
+
+  public function __construct(ClientInterface $dcx_integration_client, DcxImportServiceInterface $dcx_import_service, PrivateTempStoreFactory $temp_store_factory, AccountProxyInterface $user_account) {
     $this->dcx_integration_client = $dcx_integration_client;
+    $this->dcx_import_service = $dcx_import_service;
+    $this->store = $temp_store_factory->get(__CLASS__);
+    $this->user_account = $user_account;
   }
 
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('dcx_integration.client')
+      $container->get('dcx_integration.client'),
+      $container->get('dcx_migration.import'),
+      $container->get('user.private_tempstore'),
+      $container->get('current_user')
     );
   }
-
 
   /**
    * {@inheritdoc}
@@ -48,22 +79,52 @@ class ArticleImportForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['dcx_id'] = array(
-      '#type' => 'textfield',
-      '#title' => $this->t('DC-X ID'),
-      '#description' => 'Please give a DC-X story document id. Something like "document/doc6p9gtwruht4gze9boxi".',
-      '#maxlength' => 64,
-      '#size' => 64,
-      '#required' => TRUE,
-    );
-    $form['actions'] = array(
-      '#type' => 'actions',
-      'submit' => array(
-        '#type' => 'submit',
-        '#value' => $this->t('Import'),
-        '#button_type' => 'primary',
-      ),
-    );
+    $asset = $this->store->get('asset');
+
+    if (!$asset) { // Step 1
+      $form['dcx_id'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('DC-X ID'),
+        '#description' => 'Please give a DC-X story document id. Something like "document/doc6p9gtwruht4gze9boxi".',
+        '#maxlength' => 64,
+        '#size' => 64,
+        '#required' => TRUE,
+      ];
+      $form['actions'] = [
+        '#type' => 'actions',
+        'submit' => [
+          '#type' => 'submit',
+          '#value' => $this->t('Import'),
+          '#button_type' => 'primary',
+        ],
+      ];
+    } else { // Step 2
+      $data = $asset->data();
+
+      $form['title'] = [
+        '#markup' => "<h2>" . $data['title'] . "<h2>",
+      ];
+      $form['body'] = array(
+        '#type' => 'text_format',
+        '#default_value' => isset($data['body']) ? $data['body'] : '',
+        '#format' => 'full_html',
+      );
+      $form['actions'] = [
+        '#type' => 'actions',
+        'save' => [
+          '#type' => 'submit',
+          '#submit' => ['::saveArticle'],
+          '#value' => $this->t('Save article'),
+          '#button_type' => 'primary',
+        ],
+        'clear' => [
+          '#type' => 'submit',
+          '#submit' => ['::clearTempStore'],
+          '#value' => $this->t('Clear'),
+          '#button_type' => 'danger',
+        ],
+      ];
+    }
 
     return $form;
   }
@@ -74,12 +135,62 @@ class ArticleImportForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $dcx_id = $form_state->getValue('dcx_id');
     try {
-      $object = $this->dcx_integration_client->getObject('dcxapi:' . $dcx_id);
+      $asset = $this->dcx_integration_client->getObject('dcxapi:' . $dcx_id);
+      $this->store->set('asset', $asset);
+    } catch (\Exception $e) {
+      $this->store->delete('asset');
+      drupal_set_message($e->getMessage());
     }
-    catch (\Exception $e) {
-      dpm($e->getMessage());
+
+    $files = $asset->data()['files'];
+    $this->dcx_import_service->import($files);
+  }
+
+  public function clearTempStore(array &$form, FormStateInterface $form_state) {
+    $this->store->set('asset', NULL);
+  }
+
+  public function saveArticle(array &$form, FormStateInterface $form_state) {
+    $uid = $this->user_account->id();
+    $data = $this->store->get('asset')->data();
+
+    $title = $data['title'];
+    $body = $form_state->getValue('body')['value'];
+
+    $node = Node::create([
+        'type' => 'article',
+        'title' => $title,
+        'uid' => $uid,
+        'status' => 0,
+    ]);
+
+    $body_paragraph = Paragraph::create([
+      'type' => 'text',
+      'uid' => $uid,
+      'status' => 1,
+      'field_text' => [
+        ['value' => $body, 'format' => 'basic_html'],
+      ]
+    ]);
+    $body_paragraph->save();
+    $node->field_paragraphs->appendItem($body_paragraph);
+
+    $files = $data['files'];
+    $media_ids = $this->dcx_import_service->getEntityIds($files);
+    foreach ($media_ids as $media_id) {
+      $media_paragraph = Paragraph::create([
+        'type' => 'media',
+        'uid' => $uid,
+        'status' => 1,
+        'field_media' => [
+          ['target_id' => $media_id]
+        ],
+      ]);
+      $media_paragraph->save();
+      $node->field_paragraphs->appendItem($media_paragraph);
     }
-    dpm($object);
+
+    $node->save();
   }
 
 }

--- a/modules/dcx_article_import/src/Form/ArticleImportForm.php
+++ b/modules/dcx_article_import/src/Form/ArticleImportForm.php
@@ -90,6 +90,9 @@ class ArticleImportForm extends FormBase {
         '#maxlength' => 64,
         '#size' => 64,
         '#required' => TRUE,
+        '#attached' => [
+          'library' => ['dcx_article_import/dropzone'],
+        ],
       ];
       $form['actions'] = [
         '#type' => 'actions',

--- a/modules/dcx_article_import/src/Form/ArticleImportForm.php
+++ b/modules/dcx_article_import/src/Form/ArticleImportForm.php
@@ -12,6 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\dcx_integration\ClientInterface;
+use Drupal\dcx_integration\Exception\MandatoryAttributeException;
 use Drupal\dcx_migration\DcxImportServiceInterface;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
@@ -154,7 +155,13 @@ class ArticleImportForm extends FormBase {
     try {
       $asset = $this->dcx_integration_client->getObject('dcxapi:' . $dcx_id);
       $this->store->set('asset', $asset);
-    } catch (\Exception $e) {
+    }
+    catch (MandatoryAttributeException $e) {
+      $message = $this->t('DC-X Story %id is missing the mandatory attribute %attr. Please fix this in DC-X.', ['%id' => $dcx_id, '%attr' => $e->attribute]);
+      drupal_set_message($message);
+      return;
+    }
+    catch (\Exception $e) {
       $this->store->delete('asset');
       drupal_set_message($e->getMessage());
       return;

--- a/modules/dcx_article_import/src/Form/ArticleImportForm.php
+++ b/modules/dcx_article_import/src/Form/ArticleImportForm.php
@@ -203,8 +203,11 @@ class ArticleImportForm extends FormBase {
       $node->field_paragraphs->appendItem($body_paragraph);
     }
 
-    $files = $data['files'];
-    $media_ids = $this->dcx_import_service->getEntityIds($files);
+    $media_ids = [];
+    if ($files = $data['files']) {
+      $media_ids = $this->dcx_import_service->getEntityIds($files);
+    }
+
     foreach ($media_ids as $media_id) {
       $media_paragraph = Paragraph::create([
         'type' => 'media',

--- a/modules/dcx_article_import/src/Form/ArticleImportForm.php
+++ b/modules/dcx_article_import/src/Form/ArticleImportForm.php
@@ -54,6 +54,7 @@ class ArticleImportForm extends FormBase {
       '#description' => 'Please give a DC-X story document id. Something like "document/doc6p9gtwruht4gze9boxi".',
       '#maxlength' => 64,
       '#size' => 64,
+      '#required' => TRUE,
     );
     $form['actions'] = array(
       '#type' => 'actions',

--- a/modules/dcx_article_import/src/Form/ArticleImportForm.php
+++ b/modules/dcx_article_import/src/Form/ArticleImportForm.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\dcx_article_import\Form\ArticleImportForm.
+ */
+
+namespace Drupal\dcx_article_import\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\dcx_integration\ClientInterface;
+
+/**
+ * Class ArticleImportForm.
+ *
+ * @package Drupal\dcx_article_import\Form
+ */
+class ArticleImportForm extends FormBase {
+
+  /**
+   * Drupal\dcx_integration\ClientInterface definition.
+   *
+   * @var Drupal\dcx_integration\ClientInterface
+   */
+  protected $dcx_integration_client;
+
+  public function __construct(ClientInterface $dcx_integration_client) {
+    $this->dcx_integration_client = $dcx_integration_client;
+  }
+
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('dcx_integration.client')
+    );
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'article_import_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['dcx_id'] = array(
+      '#type' => 'textfield',
+      '#title' => $this->t('DC-X ID'),
+      '#description' => 'Please give a DC-X story document id. Something like "document/doc6p9gtwruht4gze9boxi".',
+      '#maxlength' => 64,
+      '#size' => 64,
+    );
+    $form['actions'] = array(
+      '#type' => 'actions',
+      'submit' => array(
+        '#type' => 'submit',
+        '#value' => $this->t('Import'),
+        '#button_type' => 'primary',
+      ),
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $dcx_id = $form_state->getValue('dcx_id');
+    try {
+      $object = $this->dcx_integration_client->getObject('dcxapi:' . $dcx_id);
+    }
+    catch (\Exception $e) {
+      dpm($e->getMessage());
+    }
+    dpm($object);
+  }
+
+}

--- a/modules/dcx_article_import/src/Form/ArticleImportForm.php
+++ b/modules/dcx_article_import/src/Form/ArticleImportForm.php
@@ -10,6 +10,7 @@ namespace Drupal\dcx_article_import\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
 use Drupal\dcx_integration\ClientInterface;
 use Drupal\dcx_migration\DcxImportServiceInterface;
 use Drupal\node\Entity\Node;
@@ -194,6 +195,8 @@ class ArticleImportForm extends FormBase {
     }
 
     $node->save();
-  }
 
+    $this->store->delete('asset');
+    $form_state->setRedirectUrl(Url::fromRoute('entity.node.edit_form', ['node' => $node->id()]));
+  }
 }

--- a/modules/dcx_migration/src/DcxImportService.php
+++ b/modules/dcx_migration/src/DcxImportService.php
@@ -133,4 +133,25 @@ class DcxImportService implements DcxImportServiceInterface {
     }
     drupal_set_message($fail);
   }
+
+  /**
+   * Helper to retrieve entity id for the give DC-X ID, if present.
+   *
+   * @param array of DC-X IDs
+   *
+   * @return array of entity id or FALSE, keyed by DC-X ID
+   */
+  public function getEntityIds(array $dcx_ids) {
+    $executable = $this->getMigrationExecutable();
+    $map = $executable->getMigration()->getIdMap();
+
+    $entity_ids = [];
+
+    foreach ($dcx_ids as $i) {
+      $destid = $map->lookupDestinationIds([$i]);
+      $entity_ids[$i] = $destid[0][0];
+    };
+
+    return $entity_ids;
+  }
 }

--- a/modules/dcx_migration/src/DcxImportService.php
+++ b/modules/dcx_migration/src/DcxImportService.php
@@ -130,8 +130,8 @@ class DcxImportService implements DcxImportServiceInterface {
     drupal_set_message($success);
     if (!empty($results['fail'])) {
       $fail = $t->translate('The following item(s) failed to import: @items', ['@items' => join(', ', $results['fail'])]);
+      drupal_set_message($fail);
     }
-    drupal_set_message($fail);
   }
 
   /**

--- a/modules/dcx_migration/src/DcxMigrateExecutable.php
+++ b/modules/dcx_migration/src/DcxMigrateExecutable.php
@@ -166,4 +166,12 @@ class DcxMigrateExecutable extends MigrateExecutable implements MigrateMessageIn
       ->execute();
   }
 
+  /**
+   * Gets the migration plugin.
+   *
+   * @return \Drupal\migrate\Plugin\MigrationInterface.
+   */
+  public function getMigration() {
+    return $this->migration;
+  }
 }

--- a/modules/dcx_migration/src/Plugin/migrate/source/DcxSource.php
+++ b/modules/dcx_migration/src/Plugin/migrate/source/DcxSource.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dcx_migration\Plugin\migrate\source;
 
+use Drupal\dcx_integration\Exception\IllegalAssetTypeException;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\MigrateException;
 use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
@@ -40,7 +41,11 @@ class DcxSource extends SourcePluginBase {
   }
 
   protected function getDcxObject($id) {
-    return $this->dcx_service->getObject($id);
+    $object = $this->dcx_service->getObject($id);
+    if (! $object instanceof \Drupal\dcx_integration\Asset\Image) {
+      throw new IllegalAssetTypeException($id, get_class($object), '\Drupal\dcx_integration\Asset\Image');
+    }
+    return $object;
   }
 
   public function getIDs() {

--- a/src/Asset/Article.php
+++ b/src/Asset/Article.php
@@ -8,8 +8,15 @@ namespace Drupal\dcx_integration\Asset;
  * @package Drupal\dcx_integration\Asset
  */
 class Article extends BaseAsset {
-  static $mandatory_attributes = ['id', 'title', 'headline', 'body'];
+  static $mandatory_attributes = [
+    'id',
+    'title',
+    'body'
+  ];
 
+  static $optional_attributes = [
+    'files'
+  ];
   /**
    * Constuctor.
    *
@@ -17,7 +24,7 @@ class Article extends BaseAsset {
    *   Data representing this asset.
    */
   public function __construct($data) {
-    parent::__construct($data, self::$attributes);
+    parent::__construct($data, self::$mandatory_attributes, self::$optional_attributes);
   }
 
 }

--- a/src/Asset/BaseAsset.php
+++ b/src/Asset/BaseAsset.php
@@ -25,12 +25,12 @@ abstract class BaseAsset {
    * @throws \Drupal\dcx_integration\Exception\MandatoryAttributeException
    *   if mandatory attributes are missing.
    * @throws \Drupal\dcx_integration\Exception\IllegalAttributeException
-   *   if munknown attributes are present.
+   *   if unknown attributes are present.
    */
   public function __construct($data, $mandatory_attributes, $optional_attributes = []) {
     foreach ($mandatory_attributes as $attribute) {
-      if (!isset($data[$attribute])) {
-        $e = new \MandatoryAttributeException($attribute);
+      if (!isset($data[$attribute]) || empty($data[$attribute]) ) {
+        $e = new MandatoryAttributeException($attribute);
         watchdog_exception(__METHOD__, $e);
         throw $e;
       }
@@ -39,7 +39,7 @@ abstract class BaseAsset {
     // Only allow mandatory and optional attributes.
     $unknown_attributes = array_diff(array_keys($data), array_merge($optional_attributes, $mandatory_attributes));
     if (!empty($unknown_attributes)) {
-      $e = new \IllegalAttributeException($unknown_attributes);
+      $e = new IllegalAttributeException($unknown_attributes);
       watchdog_exception(__METHOD__, $e);
       throw $e;
     }

--- a/src/Exception/IllegalAssetTypeException.php
+++ b/src/Exception/IllegalAssetTypeException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\dcx_integration\Exception;
+
+class IllegalAssetTypeException extends \Exception {
+  function __construct($id, $found_type, $expected_type) {
+    $message = sprintf("DC-X document '%s' is of type '%s'. Expecting type '%s'.", $id, $found_type, $expected_type);
+    parent::__construct($message);
+  }
+}

--- a/src/Exception/MandatoryAttributeException.php
+++ b/src/Exception/MandatoryAttributeException.php
@@ -7,8 +7,13 @@
 namespace Drupal\dcx_integration\Exception;
 
 class MandatoryAttributeException extends \Exception {
+
+  public $attribute;
+
   function __construct($attribute) {
-    $message = sprintf("Attribute %s is mandatory", $attribute);
+    $message = sprintf("Attribute '%s' is mandatory", $attribute);
     parent::__construct($message);
+
+    $this->attribute = $attribute;
   }
 }

--- a/src/JsonClient.php
+++ b/src/JsonClient.php
@@ -7,6 +7,7 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\dcx_integration\Asset\Image;
+use Drupal\dcx_integration\Asset\Article;
 
 use Drupal\dcx_integration\Exception\DcxClientException;
 
@@ -147,7 +148,7 @@ class JsonClient implements ClientInterface {
 
     switch ($type) {
       case "dcxapi:tm_topic/documenttype-story":
-        $asset = $this->buildStoryAsset($json);
+        $asset = $this->buildArticleAsset($json);
         break;
 
       case "dcxapi:tm_topic/documenttype-image":
@@ -189,15 +190,7 @@ class JsonClient implements ClientInterface {
       'kill_date' => [[$this, 'computeExpire']],
     ];
 
-    foreach ($attribute_map as $target_key => $source) {
-      if (is_array($source[0]) && method_exists($source[0][0], $source[0][1])) {
-        $callback = array_shift($source);
-        $data[$target_key] = call_user_func($callback, $json, $source);
-      }
-      elseif (is_array($source)) {
-        $data[$target_key] = $this->extractData($json, $source);
-      }
-    }
+    $data = $this->processAttributeMap($attribute_map, $json);
 
     return new Image($data);
   }
@@ -208,9 +201,46 @@ class JsonClient implements ClientInterface {
    * @return Drupal\dcx_integration\Asset\Article
    *   The Article object.
    */
-  protected function buildStoryAsset($json) {
-    // @TODO
-    throw new \Exception(__METHOD__ . " is not implemented yet");
+  protected function buildArticleAsset($json) {
+    $data = [];
+
+    $attribute_map = [
+      'id' => ['_id'],
+      'title' => ['fields', 'Headline', 0, 'value'],
+      'body' => ['fields', 'body', 0, 'value'],
+      'files' => [[$this, 'extractImageIds'], 'fields', 'Image'],
+    ];
+
+    $data = $this->processAttributeMap($attribute_map, $json);
+
+    return new Article($data);
+  }
+
+  /**
+   * Extract data specified in the attribute map on the given source array.
+   *
+   * An attribute map is an associative array.
+   * Keys will be the keys of the resulting data array.
+   * Values are arrays of keys in the source or, if the first element is a
+   * callable [object, method] pair, arguments for further processing in this
+   * very callable.
+   *
+   * @return array of extracted data
+   */
+  protected function processAttributeMap($attribute_map, $source) {
+    $data = [];
+
+    foreach ($attribute_map as $target_key => $source_keys) {
+      if (is_array($source_keys[0]) && method_exists($source_keys[0][0], $source_keys[0][1])) {
+        $callback = array_shift($source_keys);
+        $data[$target_key] = call_user_func($callback, $source, $source_keys);
+      }
+      elseif (is_array($source_keys)) {
+        $data[$target_key] = $this->extractData($source, $source_keys);
+      }
+    }
+
+    return $data;
   }
 
   /**
@@ -252,6 +282,24 @@ class JsonClient implements ClientInterface {
       '_file_url_absolute',
     ]);
     return $file_url;
+  }
+
+  /**
+   * Returns the image IDs nested in a story document.
+   *
+   * This function "knows" where to look for the IDs  in question.
+   *
+   * @param array $keys
+   * @param array $json
+   *
+   * @return array of image IDs
+   */
+  protected function extractImageIds($json, $keys) {
+    $data = $this->extractData($json, $keys);
+    foreach ($data as $image_data) {
+      $images[] = $this->extractData($image_data, ['fields', 'DocumentRef', 0, '_id']);
+    }
+    return $images;
   }
 
   /**


### PR DESCRIPTION
This provides the possibility to import articles from DC-X via a d'n'd interface, quite similar to the image import.

STR: 
- Surf to node/add/article/dcx-import
- Drag the draggable of a valid story document from DC-X to the dropzone.
- Add &lt;hr&gt; Tags to the text field provided
- Find yourself redirect to the node that was just created. Look at field_paragraphs.
