### PR TITLE
DRPLDCX-96 Avoid archiving non-existing nodes

### DIFF
--- a/modules/dcx_article_archive/src/Plugin/QueueWorker/ArticleArchiver.php
+++ b/modules/dcx_article_archive/src/Plugin/QueueWorker/ArticleArchiver.php
@@ -89,6 +89,11 @@ class ArticleArchiver extends QueueWorkerBase implements ContainerFactoryPluginI
   public function processItem($id) {
     $node = $this->entityTypeManager->getStorage('node')->load($id);
 
+    // The node might not exists anymore because it was deleted.
+    if (!$node) {
+      return;
+    }
+    
     $this->archive($node);
   }
 


### PR DESCRIPTION
If a node is saved and quickly deleted afterwards, we might end up with an invalid node id in the dcx_article_archiver queue. To avoid an error resulting from passing NULL to ArticleArchiver::archive() we need to skip archiving non-existing nodes.
