### PR TITLE
Update Image.php according to the last DAM-Update

### DIFF
--- a/src/Asset/Image.php
+++ b/src/Asset/Image.php
@@ -13,7 +13,6 @@ class Image extends BaseAsset {
     'filename',
     'title',
     'url',
-    'status',
   ];
 
   static $optional_attributes = [
@@ -23,6 +22,7 @@ class Image extends BaseAsset {
     'source',
     'price',
     'kill_date',
+    'status',
   ];
 
   /**

--- a/src/Asset/Image.php
+++ b/src/Asset/Image.php
@@ -13,6 +13,7 @@ class Image extends BaseAsset {
     'filename',
     'title',
     'url',
+    'status',
   ];
 
   static $optional_attributes = [
@@ -22,7 +23,6 @@ class Image extends BaseAsset {
     'source',
     'price',
     'kill_date',
-    'status',
   ];
 
   /**

--- a/src/JsonClient.php
+++ b/src/JsonClient.php
@@ -344,7 +344,7 @@ class JsonClient implements ClientInterface {
   protected function computeStatus($json) {
     $rights_ids = $this->extractData($json, [
       '_rights_effective',
-      'rightstype-UsagePermitted',
+      'rightstype-UsagePermittedDigital‘,
     ]);
     foreach (current($rights_ids) as $right) {
       $right_id = $right['_id'];

--- a/src/JsonClient.php
+++ b/src/JsonClient.php
@@ -344,7 +344,7 @@ class JsonClient implements ClientInterface {
   protected function computeStatus($json) {
     $rights_ids = $this->extractData($json, [
       '_rights_effective',
-      'rightstype-UsagePermittedDigital‘,
+      'rightstype-UsagePermittedDigital',
     ]);
     foreach (current($rights_ids) as $right) {
       $right_id = $right['_id'];


### PR DESCRIPTION
When I try to import images via Drag'nDrop from DAM or DEV-DAM into mylife I get an Error, that the mandatory attribute "status" is not avaiable. (Tested with https://dev-dam.burda.com/dcx/api/document/doc6t3knlo6a86naei27g1?x-doctype=documenttype-image for example).
If I move status from mandatory to optional it works without Problems. Can we merge this simple change or does it mean we get problems at another place that I don't know of ?