### PR TITLE
Use the module name as log type

### DIFF
--- a/modules/dcx_track_media_usage/src/ReferencedEntityDiscoveryService.php
+++ b/modules/dcx_track_media_usage/src/ReferencedEntityDiscoveryService.php
@@ -51,7 +51,7 @@ class ReferencedEntityDiscoveryService implements ReferencedEntityDiscoveryServi
 
       if (empty($dcx_id)) {
         $exception = new FoundNonDcxEntityException('media', 'image', $referencedEntity->id());
-        watchdog_exception(__METHOD__, $exception);
+        watchdog_exception('dcx_track_media_usage', $exception);
         throw $exception;
       }
 


### PR DESCRIPTION
![log](https://user-images.githubusercontent.com/123946/28158157-1d8625c8-67b9-11e7-9a36-cd159af94203.jpg)

The string for the log type is to long. dblog supports 64 chars only. I think its good to use the name of the module instead.